### PR TITLE
Update frontend build context in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
 
   frontend:
     build:
-      context: ./Frontend
+      context: ./Front
       dockerfile: Dockerfile
     ports:
       - "8080:8080"


### PR DESCRIPTION
This pull request includes a small change to the `docker-compose.yml` file. The change modifies the build context for the `frontend` service from `./Frontend` to `./Front`.

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L19-R19): Changed the build context for the `frontend` service from `./Frontend` to `./Front`.