### PR TITLE
Features/stm32

### DIFF
--- a/STM32-NUCLEO-F446RE/Core/Src/main.c
+++ b/STM32-NUCLEO-F446RE/Core/Src/main.c
@@ -65,7 +65,7 @@ int rgbg = 255;
 int rgbb = 255;
 
 bool rgb = false, rgb_state = false;
-bool led = true, led_state = false;
+bool led = false, led_state = false;
 bool buz = false, buz_state = false;
 bool but = false;
 bool temp_old_state = false;
@@ -567,24 +567,24 @@ void Automate_Actions(void) {
 
     }
 
-    if(rgb)
+    if (rgb) {
         rgb_state = true;
         Update_RGB_LED(rgbr, rgbg, rgbb, true);
-    else {
+    } else {
         Update_RGB_LED(rgbr, rgbg, rgbb, rgb_state);
     }
 
-    if(led)
+    if (led) {
         led_state = true;
         Update_Radiator(true);
-    else {
+    } else {
         Update_Radiator(led_state);
     }
 
-    if(buz)
+    if (buz) {
         buz_state = true;
         Update_Buzzer(true, buz_intensity);
-    else {
+    } else {
         Update_Buzzer(buz_state, buz_intensity);
     }
 }

--- a/STM32-NUCLEO-F446RE/Core/Src/main.c
+++ b/STM32-NUCLEO-F446RE/Core/Src/main.c
@@ -547,8 +547,8 @@ void Automate_Actions(void) {
         buzzer_cycles = 0;
     }
     if (tCelsius < temp_threshold) {
-        rgb_state = false;
-        led_state = false;
+        rgb_state = true;
+        led_state = true;
         if (buzzer_cycles < 4) {
             buz_state = true;
             buzzer_cycles++;
@@ -556,8 +556,8 @@ void Automate_Actions(void) {
             buz_state = false;
         }
     } else {
-        rgb_state = true;
-        led_state = true;
+        rgb_state = false;
+        led_state = false;
         if (buzzer_cycles < 4) {
             buz_state = true;
             buzzer_cycles++;

--- a/STM32-NUCLEO-F446RE/Core/Src/main.c
+++ b/STM32-NUCLEO-F446RE/Core/Src/main.c
@@ -502,7 +502,7 @@ void Update_Radiator(bool state) {
 void HAL_UART_RxCpltCallback(UART_HandleTypeDef *huart) {
     static uint16_t uart_buf2_index = 0;
 
-    if (strcmp(rx_buffer,"\n"))
+    if (strcmp(rx_buffer,"\n")){
         uart_buf2[uart_buf2_index++] = rx_buffer[0];
     } else {
         uart_buf2[uart_buf2_index] = '\0'; // Null-terminate the string

--- a/STM32-NUCLEO-F446RE/Core/Src/main.c
+++ b/STM32-NUCLEO-F446RE/Core/Src/main.c
@@ -502,7 +502,7 @@ void Update_Radiator(bool state) {
 void HAL_UART_RxCpltCallback(UART_HandleTypeDef *huart) {
     static uint16_t uart_buf2_index = 0;
 
-    if (rx_buffer[0] != '\n') {
+    if (strcmp(rx_buffer,"\n"))
         uart_buf2[uart_buf2_index++] = rx_buffer[0];
     } else {
         uart_buf2[uart_buf2_index] = '\0'; // Null-terminate the string

--- a/STM32-NUCLEO-F446RE/Core/Src/main.c
+++ b/STM32-NUCLEO-F446RE/Core/Src/main.c
@@ -502,11 +502,38 @@ void Update_Radiator(bool state) {
 void HAL_UART_RxCpltCallback(UART_HandleTypeDef *huart) {
     static uint16_t uart_buf2_index = 0;
 
-    if (strcmp(rx_buffer,"\n")){
+    if (strcmp(rx_buffer, "\n")) {
         uart_buf2[uart_buf2_index++] = rx_buffer[0];
     } else {
         uart_buf2[uart_buf2_index] = '\0'; // Null-terminate the string
-        UART_SendString(uart_buf2);
+        // UART_SendString(uart_buf2);
+        if (strncmp((char *) rx_buffer, "[LED#SWITCH:True]", 16) == 0) {
+            led = true;
+            UART_SendString("[DEBUG] LED activée\n");
+        } else if (strncmp((char *) rx_buffer, "[LED#SWITCH:False]", 17) == 0) {
+            led = false;
+            UART_SendString("[DEBUG] LED désactivée\n");
+        } else if (strncmp((char *) rx_buffer, "[BUZZER#SWITCH:True]", 19) == 0) {
+            buz = true;
+            UART_SendString("[DEBUG] Buzzer activé\n");
+        } else if (strncmp((char *) rx_buffer, "[BUZZER#SWITCH:False]", 20) == 0) {
+            buz = false;
+            UART_SendString("[DEBUG] Buzzer désactivé\n");
+        } else if (strncmp((char *) rx_buffer, "[RGB#SWITCH:True]", 16) == 0) {
+            rgb = true;
+            UART_SendString("[DEBUG] RGB activé\n");
+        } else if (strncmp((char *) rx_buffer, "[RGB#SWITCH:False]", 17) == 0) {
+            rgb = false;
+            UART_SendString("[DEBUG] RGB désactivé\n");
+        } else if (strncmp((char *) rx_buffer, "[RGB#COLOR:", 11) == 0) {
+            sscanf((char *) rx_buffer, "[RGB#COLOR:%d,%d,%d]", &rgbr, &rgbg, &rgbb);
+            UART_SendString("[DEBUG] Couleur RGB mise à jour\n");
+        } else if (strncmp((char *) rx_buffer, "[TEMP#THRESHOLD:", 16) == 0) {
+            sscanf((char *) rx_buffer, "[TEMP#THRESHOLD:%d]", &temp_threshold);
+            UART_SendString("[DEBUG] Seuil de température mis à jour\n");
+        } else {
+            UART_SendString("[DEBUG] Commande inconnue\n");
+        }
         uart_buf2_index = 0; // Reset the index for the next message
     }
 

--- a/STM32-NUCLEO-F446RE/Core/Src/main.c
+++ b/STM32-NUCLEO-F446RE/Core/Src/main.c
@@ -235,9 +235,9 @@ int main(void)
                 TCI, TCD, // Temperature
                 RHI, RHD, // Humidity
                 rgbr, rgbg, rgbb, // RGB color
-                rgb ? "true" : "false", // RGB state
-                led ? "true" : "false", // Led state
-                buz ? "true" : "false", // Buzzer state
+                rgb_state ? "true" : "false", // RGB state
+                led_state ? "true" : "false", // Led state
+                buz_state ? "true" : "false", // Buzzer state
                 but ? "true" : "false", // Button state
                 temp_threshold // Temperature threshold
         );
@@ -548,7 +548,7 @@ void Automate_Actions(void) {
     }
     if (tCelsius < temp_threshold) {
         rgb_state = true;
-        led_state = true;
+        led_state = false;
         if (buzzer_cycles < 4) {
             buz_state = true;
             buzzer_cycles++;
@@ -557,7 +557,7 @@ void Automate_Actions(void) {
         }
     } else {
         rgb_state = false;
-        led_state = false;
+        led_state = true;
         if (buzzer_cycles < 4) {
             buz_state = true;
             buzzer_cycles++;

--- a/STM32-NUCLEO-F446RE/Core/Src/main.c
+++ b/STM32-NUCLEO-F446RE/Core/Src/main.c
@@ -556,8 +556,8 @@ void Automate_Actions(void) {
             buz_state = false;
         }
     } else {
-        rgb_state = false;
-        led_state = false;
+        rgb_state = true;
+        led_state = true;
         if (buzzer_cycles < 4) {
             buz_state = true;
             buzzer_cycles++;

--- a/STM32-NUCLEO-F446RE/Core/Src/main.c
+++ b/STM32-NUCLEO-F446RE/Core/Src/main.c
@@ -500,18 +500,18 @@ void Update_Radiator(bool state) {
 }
 
 void HAL_UART_RxCpltCallback(UART_HandleTypeDef *huart) {
-        HAL_UART_Receive_IT(&huart4, rx_buffer, 1);
-        //UART_SendString(rx_buffer);
-        if (strcmp(rx_buffer,"\n")) {
-                UART_SendString(rx_buffer);
-        } else {
-                UART_SendString("[DEBUG] ESPACE\n");
-        }
+    static uint16_t uart_buf2_index = 0;
 
-            // Relancez la réception pour le prochain caractère
+    if (rx_buffer[0] != '\n') {
+        uart_buf2[uart_buf2_index++] = rx_buffer[0];
+    } else {
+        uart_buf2[uart_buf2_index] = '\0'; // Null-terminate the string
+        UART_SendString(uart_buf2);
+        uart_buf2_index = 0; // Reset the index for the next message
+    }
 
-   // HAL_UART_Receive_IT(&huart2, rx_buffer, 16);
-    //HAL_UART_Transmit(&huart2, rx_buffer, 16, 0xFFFF);
+    // Relancez la réception pour le prochain caractère
+    HAL_UART_Receive_IT(&huart4, rx_buffer, 1);
 
 }
 

--- a/STM32-NUCLEO-F446RE/Core/Src/main.c
+++ b/STM32-NUCLEO-F446RE/Core/Src/main.c
@@ -64,8 +64,8 @@ int rgbr = 255;
 int rgbg = 255;
 int rgbb = 255;
 
-bool rgb = true;
-bool led = false;
+bool rgb = false;
+bool led = true;
 bool buz = false;
 bool but = false;
 

--- a/STM32-NUCLEO-F446RE/Core/Src/main.c
+++ b/STM32-NUCLEO-F446RE/Core/Src/main.c
@@ -70,7 +70,7 @@ bool buz = false, buz_state = false;
 bool but = false;
 bool temp_old_state = false;
 
-int temp_threshold = 25;
+int temp_threshold = 30;
 int buz_intensity = 50; // Intensité du buzzer (0-100)
 
 int buzzer_cycles = 0;
@@ -547,7 +547,7 @@ void Automate_Actions(void) {
         buzzer_cycles = 0;
     }
     if (tCelsius < temp_threshold) {
-        rgb_state = true;
+        rgb_state = false;
         led_state = false;
         if (buzzer_cycles < 4) {
             buz_state = true;
@@ -557,7 +557,7 @@ void Automate_Actions(void) {
         }
     } else {
         rgb_state = false;
-        led_state = true;
+        led_state = false;
         if (buzzer_cycles < 4) {
             buz_state = true;
             buzzer_cycles++;


### PR DESCRIPTION
This pull request includes several changes to the `STM32-NUCLEO-F446RE/Core/Src/main.c` file, focusing on enhancing the automation of actions and improving the handling of UART commands. The most important changes include the introduction of a new `Automate_Actions` function, updates to the UART receive callback, and modifications to the main loop to incorporate the new automation logic.

Enhancements to automation:

* Added a new function `Automate_Actions` to automate the control of the RGB LED, radiator (LED), and buzzer based on temperature thresholds and states. [[1]](diffhunk://#diff-99f8d30cbe50eed548dd4a43f06f74185d2df52822eb8e91ca42fad7a073636bR94) [[2]](diffhunk://#diff-99f8d30cbe50eed548dd4a43f06f74185d2df52822eb8e91ca42fad7a073636bL503-R589)
* Updated the main loop to call `Automate_Actions` for periodic state updates and removed redundant manual updates for RGB LED, buzzer, and radiator.

Improved UART command handling:

* Modified the UART receive callback to handle multiple commands, including switching states of the LED, buzzer, and RGB LED, updating RGB colors, and setting temperature thresholds.
* Introduced a buffer to accumulate received UART characters until a newline is detected, allowing for complete command processing.

State management updates:

* Added new state variables (`rgb_state`, `led_state`, `buz_state`, `temp_old_state`, `buzzer_cycles`) to manage the current states of the RGB LED, radiator, and buzzer, and to track temperature changes.
* Changed the initial temperature threshold from 25 to 30.